### PR TITLE
Fix a bug: "cannot redefine property:encoding"

### DIFF
--- a/wbxml.js
+++ b/wbxml.js
@@ -400,7 +400,7 @@
       this.version = ((v & 0xf0) + 1).toString() + '.' + (v & 0x0f).toString();
       this.pid = this._get_mb_uint32();
       this.charset = mib2str[this._get_mb_uint32()] || 'unknown';
-      this._decoder = TextDecoder(this.charset);
+      this._decoder = new TextDecoder(this.charset);
 
       var tbl_len = this._get_mb_uint32();
       this.strings = new StringTable(this._get_slice(tbl_len), this._decoder);


### PR DESCRIPTION
I found your code in line 403 didn't construct the `TextDecoder` object, it means that you do define "encoding" property one by one, then it will throw the error.
