### PR TITLE
Improve EventParser so it doesn't slurp the entire sub-DOM when it finds a matching node

### DIFF
--- a/eventparser.js
+++ b/eventparser.js
@@ -1,0 +1,168 @@
+/* Copyright 2014 Mozilla Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+(function (root, factory) {
+  // node.js
+  if (typeof exports === 'object') {
+    module.exports = factory();
+    this.Blob = require('./blob').Blob;
+    var stringencoding = require('stringencoding');
+    this.TextEncoder = stringencoding.TextEncoder;
+    this.TextDecoder = stringencoding.TextDecoder;
+  }
+  // browser environment, AMD loader
+  else if (typeof define === 'function' && define.amd) {
+    define(factory);
+  }
+  // browser environment, no AMD loader
+  else {
+    root.WBXMLEventParser = factory();
+  }
+}(this, function() {
+  'use strict';
+
+  function EventParser() {
+    this._running = false;
+    this._fullPath = null;
+
+    // The currently-running listener.
+    this._currentListener = null;
+
+    // An array of listeners at the root level.
+    this._listeners = [];
+
+    // An array of nested listener sets; each element contains a |depth| and
+    // an array of |listeners|.
+    this._activeListeners = [];
+  }
+
+  EventParser.prototype = {
+    on: function(path, callback) {
+      this._on(path, 'open', callback);
+    },
+
+    onend: function(path, callback) {
+      if (typeof path === 'function') {
+        this._on([], 'close', path);
+      } else {
+        this._on(path, 'close', callback);
+      }
+    },
+
+    _on: function(path, mode, callback) {
+      var listeners;
+
+      if (this._running) {
+        path = this._fullPath.concat(path);
+        listeners = this._currentListener.listeners;
+      }
+      else {
+        listeners = this._listeners;
+      }
+
+      listeners.push({
+        path: path,
+        mode: mode,
+        callback: callback,
+      });
+    },
+
+    run: function(reader) {
+      this._fullPath = [];
+      this._running = true;
+
+      var doc = reader.document;
+      var doclen = doc.length;
+      for (var iNode = 0; iNode < doclen; iNode++) {
+        var node = doc[iNode];
+        if (node.type !== 'ETAG') {
+          var pathElement;
+          switch (node.type) {
+          case 'STAG':
+          case 'TAG':
+            pathElement = node.tag;
+            break;
+          case 'TEXT':
+            pathElement = 'text';
+            break;
+          case 'EXT':
+            pathElement = 'ext';
+            break;
+          case 'PI':
+            pathElement = 'pi';
+            break;
+          case 'OPAQUE':
+            pathElement = 'opaque';
+            break;
+          }
+
+          this._fullPath.push(pathElement);
+          this._fireListeners(node, 'open');
+        }
+
+        if (node.type !== 'STAG') {
+          this._fireListeners(node, 'close');
+          this._fullPath.pop();
+          this._clearListeners();
+        }
+      }
+
+      this._running = false;
+    },
+
+    _fireListeners: function(node, mode) {
+      var fireIfMatched = function(listener) {
+        if (mode !== listener.mode ||
+            !this._matchPath(this._fullPath, listener.path)) {
+          return;
+        }
+
+        this._currentListener = {
+          depth: this._fullPath.length,
+          listeners: [],
+        };
+        this._activeListeners.push(this._currentListener);
+        listener.callback(node);
+        this._currentListener = null;
+      }.bind(this);
+
+      this._listeners.forEach(fireIfMatched);
+      this._activeListeners.forEach(function(active) {
+        active.listeners.forEach(fireIfMatched);
+      });
+    },
+
+    _clearListeners: function() {
+      var fullPath = this._fullPath;
+      this._activeListeners = this._activeListeners.filter(function(listener) {
+        return listener.depth <= fullPath.length;
+      });
+    },
+
+    _matchPath: function(a, b) {
+      return a.length === b.length && a.every(function(val, i) {
+        if (b[i] === '*') {
+          return true;
+        } else if (Array.isArray(b[i])) {
+          return b[i].indexOf(val) !== -1;
+        } else {
+          return val === b[i];
+        }
+      });
+    },
+  };
+
+  return EventParser;
+}));

--- a/pathreader.js
+++ b/pathreader.js
@@ -28,13 +28,13 @@
   }
   // browser environment, no AMD loader
   else {
-    root.WBXMLEventParser = factory();
+    root.WBXMLPathReader = factory();
   }
 }(this, function() {
   'use strict';
 
   /**
-   * Create a new EventParser. EventParsers are objects that allow you to listen
+   * Create a new PathReader. PathReaders are objects that allow you to listen
    * for a certain path to be emitted from an WBXML Reader, sort of like a
    * simplified version of XPath.
    *
@@ -49,7 +49,7 @@
    * can use the strings 'text', 'ext', 'pi', and 'opaque' to match text nodes,
    * extension nodes, processing instructions, or opaque blobs, respectively.
    */
-  function EventParser() {
+  function PathReader() {
     this._running = false;
     this._fullPath = null;
 
@@ -64,7 +64,7 @@
     this._innerListeners = [];
   }
 
-  EventParser.prototype = {
+  PathReader.prototype = {
     /**
      * Register a listener for a particular path. Fires when the reader emits
      * the opening tag in question.
@@ -227,5 +227,5 @@
     }
   };
 
-  return EventParser;
+  return PathReader;
 }));

--- a/test/helpers.js
+++ b/test/helpers.js
@@ -1,4 +1,4 @@
-/* Copyright 2012 Mozilla Foundation
+/* Copyright 2012-2014 Mozilla Foundation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,11 +19,6 @@ var chai = require('chai');
 var assert = chai.assert;
 // We want backtraces since we don't really use messages
 chai.Assertion.includeStack = true;
-
-function print(s) {
-  var output = document.getElementById('output');
-  output.textContent += s;
-}
 
 // Typed arrays don't compare well out of box; == and === don't work and deep
 // equals will be too deep because it will go into the buffer instances,
@@ -126,20 +121,6 @@ function verify_document(reader, expectedVersion, expectedPid, expectedCharset,
   }
 }
 
-function verify_subdocument(actual, expected) {
-  verify_node(actual, expected);
-  if (actual.children || expected.children) {
-    // 'children' may be omitted if empty; need to normalize
-    var expectedKids = expected.children || [];
-    assert.equal(actual.children.length, expectedKids.length);
-    for (var i = 0; i < actual.children.length; i++) {
-      var actualChild = actual.children[i];
-      var expectedChild = expectedKids[i];
-      verify_subdocument(actualChild, expectedChild);
-    }
-  }
-}
-
 /**
  * Create a typed array from an array or a string that we treat as a binary
  * string.
@@ -157,6 +138,6 @@ function binify(src) {
   return dest;
 }
 
+exports.verify_node = verify_node;
 exports.verify_document = verify_document;
-exports.verify_subdocument = verify_subdocument;
 exports.binify = binify;

--- a/test/test_event.js
+++ b/test/test_event.js
@@ -1,4 +1,4 @@
-/* Copyright 2012 Mozilla Foundation
+/* Copyright 2012-2014 Mozilla Foundation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,10 +18,10 @@
 var mocha = require('mocha'),
     assert = require('chai').assert,
     WBXML = require('../wbxml'),
+    EventParser = require('../eventparser'),
     helpers = require('./helpers');
 
-var verify_document = helpers.verify_document;
-var verify_subdocument  = helpers.verify_subdocument;
+var verify_node = helpers.verify_node;
 
 describe('event', function() {
 
@@ -49,11 +49,12 @@ it('basic', function test_event_basic() {
       .tag(cp.CARD)
     .etag();
 
-  var expectedSubdoc1 = { type: 'TAG', tag: cp.CARD, localTagName: 'CARD' };
-
-  var e1 = new WBXML.EventParser();
-  e1.addEventListener([cp.ROOT, cp.CARD], function(subdoc) {
-    verify_subdocument(subdoc, expectedSubdoc1);
+  var e1 = new EventParser();
+  e1.on([cp.ROOT, cp.CARD], function(node) {
+    verify_node(node, { type: 'TAG', tag: cp.CARD, localTagName: 'CARD' });
+  });
+  e1.onend([cp.ROOT, cp.CARD], function(node) {
+    verify_node(node, { type: 'TAG', tag: cp.CARD, localTagName: 'CARD' });
   });
   e1.run(new WBXML.Reader(w1, codepages));
 
@@ -65,18 +66,26 @@ it('basic', function test_event_basic() {
       .etag()
     .etag();
 
-  var expectedSubdoc2 =
-    { type: 'TAG', tag: cp.CARD, localTagName: 'CARD', children: [
-      { type: 'TAG', tag: cp.FIELD, localTagName: 'FIELD',
-        attributes: { TYPE: 'NAME' }, children: [
-          { type: 'TEXT', textContent: 'Anne' },
-        ] },
-      { type: 'TEXT', textContent: 'anne@anne.com' },
-    ]};
+  var e2 = new EventParser();
+  e2.on([cp.ROOT, cp.CARD], function(node) {
+    verify_node(node, { type: 'STAG', tag: cp.CARD, localTagName: 'CARD' });
 
-  var e2 = new WBXML.EventParser();
-  e2.addEventListener([cp.ROOT, cp.CARD], function(subdoc) {
-    verify_subdocument(subdoc, expectedSubdoc2);
+    e2.on([cp.FIELD], function(node) {
+      verify_node(node, { type: 'STAG', tag: cp.FIELD, localTagName: 'FIELD',
+                          attributes: { TYPE: 'NAME' } });
+
+      e2.on(['text'], function(node) {
+        verify_node(node, { type: 'TEXT', textContent: 'Anne' });
+      });
+    });
+
+    e2.on(['text'], function(node) {
+      verify_node(node, { type: 'TEXT', textContent: 'anne@anne.com' });
+    });
+
+    e2.onend(function(node) {
+      verify_node(node, { type: 'ETAG', tag: cp.CARD, localTagName: 'CARD' });
+    });
   });
   e2.run(new WBXML.Reader(w2, codepages));
 });
@@ -108,27 +117,36 @@ it('overlapped', function test_event_overlapped() {
      .etag()
    .etag();
 
-  var e = new WBXML.EventParser();
+  var e = new EventParser();
 
-  e.addEventListener([cp.ROOT, cp.CARD], function(subdoc) {
-    var expectedSubdoc =
-      { type: 'TAG', tag: cp.CARD, localTagName: 'CARD', children: [
-        { type: 'TAG', tag: cp.FIELD, localTagName: 'FIELD',
-          attributes: { TYPE: 'NAME' }, children: [
-            { type: 'TEXT', textContent: 'Anne' },
-          ] },
-        { type: 'TEXT', textContent: 'anne@anne.com' },
-      ]};
-    verify_subdocument(subdoc, expectedSubdoc);
+  e.on([cp.ROOT, cp.CARD], function(node) {
+    verify_node(node, { type: 'STAG', tag: cp.CARD, localTagName: 'CARD' });
+
+    e.on([cp.FIELD], function(node) {
+      verify_node(node, { type: 'STAG', tag: cp.FIELD, localTagName: 'FIELD',
+                          attributes: { TYPE: 'NAME' } });
+
+      e.on(['text'], function(node) {
+        verify_node(node, { type: 'TEXT', textContent: 'Anne' });
+      });
+    });
+
+    e.on(['text'], function(node) {
+      verify_node(node, { type: 'TEXT', textContent: 'anne@anne.com' });
+    });
+
+    e.onend(function(node) {
+      verify_node(node, { type: 'ETAG', tag: cp.CARD, localTagName: 'CARD' });
+    });
   });
 
-  e.addEventListener([cp.ROOT, cp.CARD, cp.FIELD], function(subdoc) {
-    var expectedSubdoc =
-      { type: 'TAG', tag: cp.FIELD, localTagName: 'FIELD',
-        attributes: { TYPE: 'NAME' }, children: [
-          { type: 'TEXT', textContent: 'Anne' },
-        ] };
-    verify_subdocument(subdoc, expectedSubdoc);
+  e.on([cp.ROOT, cp.CARD, cp.FIELD], function(node) {
+    verify_node(node, { type: 'STAG', tag: cp.FIELD, localTagName: 'FIELD',
+                        attributes: { TYPE: 'NAME' } });
+
+    e.on(['text'], function(node) {
+      verify_node(node, { type: 'TEXT', textContent: 'Anne' });
+    });
   });
 
   e.run(new WBXML.Reader(w, codepages));

--- a/test/test_pathreader.js
+++ b/test/test_pathreader.js
@@ -18,14 +18,14 @@
 var mocha = require('mocha'),
     assert = require('chai').assert,
     WBXML = require('../wbxml'),
-    EventParser = require('../eventparser'),
+    PathReader = require('../pathreader'),
     helpers = require('./helpers');
 
 var verify_node = helpers.verify_node;
 
 describe('event', function() {
 
-it('basic', function test_event_basic() {
+it('basic', function test_pathreader_basic() {
   var codepages = {
     Default: {
       Tags: {
@@ -49,14 +49,14 @@ it('basic', function test_event_basic() {
       .tag(cp.CARD)
     .etag();
 
-  var e1 = new EventParser();
-  e1.on([cp.ROOT, cp.CARD], function(node) {
+  var r1 = new PathReader();
+  r1.on([cp.ROOT, cp.CARD], function(node) {
     verify_node(node, { type: 'TAG', tag: cp.CARD, localTagName: 'CARD' });
   });
-  e1.onend([cp.ROOT, cp.CARD], function(node) {
+  r1.onend([cp.ROOT, cp.CARD], function(node) {
     verify_node(node, { type: 'TAG', tag: cp.CARD, localTagName: 'CARD' });
   });
-  e1.run(new WBXML.Reader(w1, codepages));
+  r1.run(new WBXML.Reader(w1, codepages));
 
   var w2 = new WBXML.Writer('1.1', 1, 'UTF-8');
   w2.stag(cp.ROOT)
@@ -66,31 +66,31 @@ it('basic', function test_event_basic() {
       .etag()
     .etag();
 
-  var e2 = new EventParser();
-  e2.on([cp.ROOT, cp.CARD], function(node) {
+  var r2 = new PathReader();
+  r2.on([cp.ROOT, cp.CARD], function(node) {
     verify_node(node, { type: 'STAG', tag: cp.CARD, localTagName: 'CARD' });
 
-    e2.on([cp.FIELD], function(node) {
+    r2.on([cp.FIELD], function(node) {
       verify_node(node, { type: 'STAG', tag: cp.FIELD, localTagName: 'FIELD',
                           attributes: { TYPE: 'NAME' } });
 
-      e2.on(['text'], function(node) {
+      r2.on(['text'], function(node) {
         verify_node(node, { type: 'TEXT', textContent: 'Anne' });
       });
     });
 
-    e2.on(['text'], function(node) {
+    r2.on(['text'], function(node) {
       verify_node(node, { type: 'TEXT', textContent: 'anne@anne.com' });
     });
 
-    e2.onend(function(node) {
+    r2.onend(function(node) {
       verify_node(node, { type: 'ETAG', tag: cp.CARD, localTagName: 'CARD' });
     });
   });
-  e2.run(new WBXML.Reader(w2, codepages));
+  r2.run(new WBXML.Reader(w2, codepages));
 });
 
-it('overlapped', function test_event_overlapped() {
+it('overlapped', function test_pathreader_overlapped() {
   var codepages = {
     Default: {
       Tags: {
@@ -117,39 +117,39 @@ it('overlapped', function test_event_overlapped() {
      .etag()
    .etag();
 
-  var e = new EventParser();
+  var r = new PathReader();
 
-  e.on([cp.ROOT, cp.CARD], function(node) {
+  r.on([cp.ROOT, cp.CARD], function(node) {
     verify_node(node, { type: 'STAG', tag: cp.CARD, localTagName: 'CARD' });
 
-    e.on([cp.FIELD], function(node) {
+    r.on([cp.FIELD], function(node) {
       verify_node(node, { type: 'STAG', tag: cp.FIELD, localTagName: 'FIELD',
                           attributes: { TYPE: 'NAME' } });
 
-      e.on(['text'], function(node) {
+      r.on(['text'], function(node) {
         verify_node(node, { type: 'TEXT', textContent: 'Anne' });
       });
     });
 
-    e.on(['text'], function(node) {
+    r.on(['text'], function(node) {
       verify_node(node, { type: 'TEXT', textContent: 'anne@anne.com' });
     });
 
-    e.onend(function(node) {
+    r.onend(function(node) {
       verify_node(node, { type: 'ETAG', tag: cp.CARD, localTagName: 'CARD' });
     });
   });
 
-  e.on([cp.ROOT, cp.CARD, cp.FIELD], function(node) {
+  r.on([cp.ROOT, cp.CARD, cp.FIELD], function(node) {
     verify_node(node, { type: 'STAG', tag: cp.FIELD, localTagName: 'FIELD',
                         attributes: { TYPE: 'NAME' } });
 
-    e.on(['text'], function(node) {
+    r.on(['text'], function(node) {
       verify_node(node, { type: 'TEXT', textContent: 'Anne' });
     });
   });
 
-  e.run(new WBXML.Reader(w, codepages));
+  r.run(new WBXML.Reader(w, codepages));
 });
 
 }); // describe

--- a/test/test_reader.js
+++ b/test/test_reader.js
@@ -1,4 +1,4 @@
-/* Copyright 2012 Mozilla Foundation
+/* Copyright 2012-2014 Mozilla Foundation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -21,7 +21,6 @@ var mocha = require('mocha'),
     helpers = require('./helpers');
 
 var verify_document = helpers.verify_document;
-var verify_subdocument  = helpers.verify_subdocument;
 var binify = helpers.binify;
 
 describe('reader', function() {

--- a/test/test_writer.js
+++ b/test/test_writer.js
@@ -1,4 +1,4 @@
-/* Copyright 2012 Mozilla Foundation
+/* Copyright 2012-2014 Mozilla Foundation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -22,7 +22,6 @@ var mocha = require('mocha'),
     blobMod = require('../blob');
 
 var verify_document = helpers.verify_document;
-var verify_subdocument  = helpers.verify_subdocument;
 var binify = helpers.binify;
 
 var Blob = blobMod.Blob;


### PR DESCRIPTION
@asutherland: Here's a PR to improve how EventParser works. It's now a little bit more event-driven, and when you find a matching node, you can create new events for the sub-tree. This lets us avoid building the entire sub-DOM, and should eliminate (or at least replace) some of the awkward boilerplate in GELAM.
